### PR TITLE
Unbind enter, set original language as default

### DIFF
--- a/sticknotes-frontend/src/app/board-container/board-container.component.ts
+++ b/sticknotes-frontend/src/app/board-container/board-container.component.ts
@@ -22,7 +22,7 @@ export class BoardContainerComponent {
   public iconName = 'menu';
   // used to receive data from the board and to send updates to the board component
   public boardData: BoardData = null;
-  public translateFormControl = new FormControl('', [Validators.required]);
+  public translateFormControl = new FormControl("original", [Validators.required]);
   public targetLanguage: string = null;
   // flag for storing user's permission to edit the board
   public canEditBoard = false;

--- a/sticknotes-frontend/src/app/new-note/new-note.component.html
+++ b/sticknotes-frontend/src/app/new-note/new-note.component.html
@@ -2,7 +2,7 @@
   <form [formGroup]="newNoteForm" class="new-note-form">
     <mat-form-field>
       <mat-label>Note</mat-label>
-      <textarea matInput formControlName="content" (keydown.enter)="handleSubmit()" cdkTextareaAutosize
+      <textarea matInput formControlName="content" cdkTextareaAutosize
         placeholder="What would you like to note?" #autosize="cdkTextareaAutosize" cdkAutosizeMinRows="1"
         cdkAutosizeMaxRows="5"></textarea>
       <mat-error *ngIf="!this.newNoteForm.valid">


### PR DESCRIPTION
* Fixes #91
* Adds "original language" as default value of translation form control